### PR TITLE
fix(parser): limit check for empty assets to only <link/> and <script/> tags

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,11 +20,10 @@ class HtmlWebpackExcludeEmptyAssetsPlugin {
 
   processAssets(pluginData, compilation) {
     const base = JSON.parse(pluginData.plugin.assetJson)[0];
-    const filterTag = (tag) => {
-        return !["link", "script"].includes(tag.tagName) ||
-          !Boolean(tag.attributes) ||
-          !this.isEmpty(tag.attributes.src || tag.attributes.href, base, compilation);
-    };
+    const filterTag = tag =>
+        !["link", "script"].includes(tag.tagName) ||
+        !Boolean(tag.attributes) ||
+        !this.isEmpty(tag.attributes.src || tag.attributes.href, base, compilation);
 
     return {
       head: pluginData.head.filter(filterTag),

--- a/index.js
+++ b/index.js
@@ -20,20 +20,15 @@ class HtmlWebpackExcludeEmptyAssetsPlugin {
 
   processAssets(pluginData, compilation) {
     const base = JSON.parse(pluginData.plugin.assetJson)[0];
-    const head = pluginData.head.filter(
-      tag =>
-        !Boolean(tag.attributes) ||
-        !this.isEmpty(tag.attributes.src || tag.attributes.href, base, compilation)
-    );
-    const body = pluginData.body.filter(
-      tag =>
-        !Boolean(tag.attributes) ||
-        !this.isEmpty(tag.attributes.src || tag.attributes.href, base, compilation)
-    );
+    const filterTag = (tag) => {
+        return !["link", "script"].includes(tag.tagName) ||
+          !Boolean(tag.attributes) ||
+          !this.isEmpty(tag.attributes.src || tag.attributes.href, base, compilation);
+    };
 
     return {
-      head,
-      body,
+      head: pluginData.head.filter(filterTag),
+      body: pluginData.body.filter(filterTag),
       plugin: pluginData.plugin,
       chunks: pluginData.chunks,
       outputName: pluginData.outputName


### PR DESCRIPTION
Fixes #1.

Only specific tags should be processed to not conflict with other injected tags to `<head/>` or `<body/>`